### PR TITLE
[code] drop PHPUnit 9 support, require PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "~6.0|~8.0",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^10.5"
     }
 }

--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -103,7 +103,7 @@ trait MatchesSnapshots
         return sprintf(
             '%s__%s__%s',
             (new ReflectionClass($this))->getShortName(),
-            $this->getName() ?? '',
+            $this->name(),
             $this->snapshotIncrementer
         );
     }


### PR DESCRIPTION
## Summary
- Replace removed \`TestCase::getName()\` with \`TestCase::name()\` in \`MatchesSnapshots::getSnapshotId()\`
- Bump \`require-dev\` phpunit constraint to \`^10.5\`

## Why
PHPUnit 10 removed \`TestCase::getName()\`. Consumers who bump to PHPUnit 10 hit \`Call to undefined method\`. Cleanest fix is to drop PHPUnit 9 support and call \`name()\` directly — release this as **0.10.0** (breaking in 0.x semver).

## Release plan
Tag \`0.10.0\` after merge.