### PR TITLE
[fix] use nameWithDataSet() to keep data-set in snapshot id

### DIFF
--- a/src/MatchesSnapshots.php
+++ b/src/MatchesSnapshots.php
@@ -103,7 +103,7 @@ trait MatchesSnapshots
         return sprintf(
             '%s__%s__%s',
             (new ReflectionClass($this))->getShortName(),
-            $this->name(),
+            $this->nameWithDataSet(),
             $this->snapshotIncrementer
         );
     }


### PR DESCRIPTION
## Summary
- \`name()\` returns only the method name; multi-data-set tests collide to the same snapshot file
- \`nameWithDataSet()\` preserves the PHPUnit 9 \`getName()\` behaviour (method + data set label)

## Why
Follow-up to 0.10.0. With plain \`name()\`, a test with N data sets writes all snapshots to the same filename.

## Release plan
Tag \`0.10.1\` after merge.